### PR TITLE
Proposal/sdo template cleanup

### DIFF
--- a/soem_interface/include/soem_interface/EthercatBusBase.hpp
+++ b/soem_interface/include/soem_interface/EthercatBusBase.hpp
@@ -36,11 +36,14 @@
 #include <message_logger/message_logger.hpp>
 
 // soem_interface
-#include <soem_interface/EthercatSlaveBase.hpp>
 #include <soem_interface/common/Macros.hpp>
 #include <soem_interface/common/ThreadSleep.hpp>
 
 namespace soem_interface {
+
+// forward declaration for EthercatSlaveBase
+class EthercatSlaveBase;
+using EthercatSlaveBasePtr = std::shared_ptr<EthercatSlaveBase>;
 
 /**
  * @brief      Class for managing an ethercat bus containing one or multpile

--- a/soem_interface/include/soem_interface/EthercatSlaveBase.hpp
+++ b/soem_interface/include/soem_interface/EthercatSlaveBase.hpp
@@ -179,6 +179,98 @@ class EthercatSlaveBase {
    */
   virtual bool sendSdoReadVisibleString(const uint16_t index, const uint8_t subindex, std::string& value);
 
+  /**
+   * Type-suffixed SDO calls.
+   * @deprecated Use the templated sendSdoRead<...> and sendSdoWrite<...> instead.
+   */
+  virtual bool sendSdoReadInt8(const uint16_t index, const uint8_t subindex, const bool completeAccess, int8_t& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadInt16(const uint16_t index, const uint8_t subindex, const bool completeAccess, int16_t& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadInt32(const uint16_t index, const uint8_t subindex, const bool completeAccess, int32_t& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadInt64(const uint16_t index, const uint8_t subindex, const bool completeAccess, int64_t& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadUInt8(const uint16_t index, const uint8_t subindex, const bool completeAccess, uint8_t& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadUInt16(const uint16_t index, const uint8_t subindex, const bool completeAccess, uint16_t& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadUInt32(const uint16_t index, const uint8_t subindex, const bool completeAccess, uint32_t& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadUInt64(const uint16_t index, const uint8_t subindex, const bool completeAccess, uint64_t& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadFloat(const uint16_t index, const uint8_t subindex, const bool completeAccess, float& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadDouble(const uint16_t index, const uint8_t subindex, const bool completeAccess, double& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoReadString(const uint16_t index, const uint8_t subindex, const bool completeAccess, std::string& value) {
+    return sendSdoRead(index, subindex, completeAccess, value);
+  }
+
+  virtual bool sendSdoWriteInt8(const uint16_t index, const uint8_t subindex, const bool completeAccess, const int8_t value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteInt16(const uint16_t index, const uint8_t subindex, const bool completeAccess, const int16_t value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteInt32(const uint16_t index, const uint8_t subindex, const bool completeAccess, const int32_t value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteInt64(const uint16_t index, const uint8_t subindex, const bool completeAccess, const int64_t value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteUInt8(const uint16_t index, const uint8_t subindex, const bool completeAccess, const uint8_t value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteUInt16(const uint16_t index, const uint8_t subindex, const bool completeAccess, const uint16_t value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteUInt32(const uint16_t index, const uint8_t subindex, const bool completeAccess, const uint32_t value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteUInt64(const uint16_t index, const uint8_t subindex, const bool completeAccess, const uint64_t value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteFloat(const uint16_t index, const uint8_t subindex, const bool completeAccess, const float value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteDouble(const uint16_t index, const uint8_t subindex, const bool completeAccess, const double value) {
+    return sendSdoWrite(index, subindex, false, value);
+  }
+
+  virtual bool sendSdoWriteString(const uint16_t index, const uint8_t subindex, const bool completeAccess, const std::string value) {
+      return sendSdoWrite(index, subindex, false, value);
+  }
+
  protected:
   /**
    * @brief      Prints a warning. Use this method to suppress compiler warnings

--- a/soem_interface/include/soem_interface/EthercatSlaveBase.hpp
+++ b/soem_interface/include/soem_interface/EthercatSlaveBase.hpp
@@ -30,9 +30,11 @@
 // message_logger
 #include <message_logger/message_logger.hpp>
 
+// soem_interface
+#include <soem_interface/EthercatBusBase.hpp>
+
 namespace soem_interface {
 
-class EthercatBusBase;
 
 /**
  * @brief      Base class for generic ethercat slaves using soem
@@ -123,7 +125,10 @@ class EthercatSlaveBase {
    * @return True if successful.
    */
   template <typename Value>
-  bool sendSdoWrite(const uint16_t index, const uint8_t subindex, const bool completeAccess, const Value value);
+  bool sendSdoWrite(const uint16_t index, const uint8_t subindex, const bool completeAccess, const Value value) {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    return bus_->sendSdoWrite(address_, index, subindex, completeAccess, value);
+  }
 
   /*!
    * Send a reading SDO.
@@ -134,99 +139,21 @@ class EthercatSlaveBase {
    * @return True if successful.
    */
   template <typename Value>
-  bool sendSdoRead(const uint16_t index, const uint8_t subindex, const bool completeAccess, Value& value);
-
-  // Send SDOs.
-  virtual bool sendSdoReadInt8(const uint16_t index, const uint8_t subindex, const bool completeAccess, int8_t& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
+  bool sendSdoRead(const uint16_t index, const uint8_t subindex, const bool completeAccess, Value& value) {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    return bus_->sendSdoRead(address_, index, subindex, completeAccess, value);
   }
 
-  virtual bool sendSdoReadInt16(const uint16_t index, const uint8_t subindex, const bool completeAccess, int16_t& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadInt32(const uint16_t index, const uint8_t subindex, const bool completeAccess, int32_t& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadInt64(const uint16_t index, const uint8_t subindex, const bool completeAccess, int64_t& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadUInt8(const uint16_t index, const uint8_t subindex, const bool completeAccess, uint8_t& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadUInt16(const uint16_t index, const uint8_t subindex, const bool completeAccess, uint16_t& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadUInt32(const uint16_t index, const uint8_t subindex, const bool completeAccess, uint32_t& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadUInt64(const uint16_t index, const uint8_t subindex, const bool completeAccess, uint64_t& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadFloat(const uint16_t index, const uint8_t subindex, const bool completeAccess, float& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadDouble(const uint16_t index, const uint8_t subindex, const bool completeAccess, double& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoReadString(const uint16_t index, const uint8_t subindex, const bool completeAccess, std::string& value) {
-    return sendSdoRead(index, subindex, completeAccess, value);
-  }
-
-  virtual bool sendSdoWriteInt8(const uint16_t index, const uint8_t subindex, const bool completeAccess, const int8_t value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteInt16(const uint16_t index, const uint8_t subindex, const bool completeAccess, const int16_t value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteInt32(const uint16_t index, const uint8_t subindex, const bool completeAccess, const int32_t value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteInt64(const uint16_t index, const uint8_t subindex, const bool completeAccess, const int64_t value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteUInt8(const uint16_t index, const uint8_t subindex, const bool completeAccess, const uint8_t value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteUInt16(const uint16_t index, const uint8_t subindex, const bool completeAccess, const uint16_t value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteUInt32(const uint16_t index, const uint8_t subindex, const bool completeAccess, const uint32_t value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteUInt64(const uint16_t index, const uint8_t subindex, const bool completeAccess, const uint64_t value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteFloat(const uint16_t index, const uint8_t subindex, const bool completeAccess, const float value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteDouble(const uint16_t index, const uint8_t subindex, const bool completeAccess, const double value) {
-    return sendSdoWrite(index, subindex, false, value);
-  }
-
-  virtual bool sendSdoWriteString(const uint16_t index, const uint8_t subindex, const bool completeAccess, const std::string value) {
-      return sendSdoWrite(index, subindex, false, value);
-  }
-
+  /**
+   * Send a generic reading SDO.
+   * @warning Not implemented!
+   */
   virtual bool sendSdoReadGeneric(const std::string& indexString, const std::string& subindexString, const std::string& valueTypeString,
                                   std::string& valueString);
+  /**
+   * Send a generic writing SDO.
+   * @warning Not implemented!
+   */
   virtual bool sendSdoWriteGeneric(const std::string& indexString, const std::string& subindexString, const std::string& valueTypeString,
                                    const std::string& valueString);
 

--- a/soem_interface/include/soem_interface/EthercatSlaveBase.hpp
+++ b/soem_interface/include/soem_interface/EthercatSlaveBase.hpp
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <typeinfo>
 
 // message_logger
 #include <message_logger/message_logger.hpp>
@@ -127,7 +128,13 @@ class EthercatSlaveBase {
   template <typename Value>
   bool sendSdoWrite(const uint16_t index, const uint8_t subindex, const bool completeAccess, const Value value) {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
-    return bus_->sendSdoWrite(address_, index, subindex, completeAccess, value);
+    const bool success =  bus_->sendSdoWrite(address_, index, subindex, completeAccess, value);
+    if(!success) {
+      MELO_ERROR_STREAM("Error writing SDO.\tAddress: " << address_ << "Index: " << (int)index
+                        << "\nSubindex: " << (int)subindex << "\n Complete Access: "
+                        << (int)completeAccess << "\nType: " << typeid(value).name());
+    }
+    return success;
   }
 
   /*!
@@ -141,7 +148,13 @@ class EthercatSlaveBase {
   template <typename Value>
   bool sendSdoRead(const uint16_t index, const uint8_t subindex, const bool completeAccess, Value& value) {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
-    return bus_->sendSdoRead(address_, index, subindex, completeAccess, value);
+    const bool success = bus_->sendSdoRead(address_, index, subindex, completeAccess, value);
+    if(!success) {
+      MELO_ERROR_STREAM("Error reading SDO.\tAddress: " << address_ << "Index: " << (int)index
+                        << "\nSubindex: " << (int)subindex << "\n Complete Access: "
+                        << (int)completeAccess << "\nType: " << typeid(value).name());
+    }
+    return success;
   }
 
   /**

--- a/soem_interface/src/soem_interface/EthercatBusBase.cpp
+++ b/soem_interface/src/soem_interface/EthercatBusBase.cpp
@@ -21,6 +21,7 @@
 */
 
 #include <soem_interface/EthercatBusBase.hpp>
+#include <soem_interface/EthercatSlaveBase.hpp>
 
 namespace soem_interface {
 

--- a/soem_interface/src/soem_interface/EthercatSlaveBase.cpp
+++ b/soem_interface/src/soem_interface/EthercatSlaveBase.cpp
@@ -21,7 +21,6 @@
 */
 
 //  soem_interface
-#include <soem_interface/EthercatBusBase.hpp>
 #include <soem_interface/EthercatSlaveBase.hpp>
 
 namespace soem_interface {
@@ -29,65 +28,6 @@ namespace soem_interface {
 EthercatSlaveBase::EthercatSlaveBase(EthercatBusBase* bus, const uint32_t address) : bus_(bus), address_(address) {}
 EthercatSlaveBase::EthercatSlaveBase() : bus_(nullptr), address_(0) {}
 
-// This definition must not be in the header, because of the forward declaration of EthercatBus
-template <typename Value>
-bool EthercatSlaveBase::sendSdoWrite(const uint16_t index, const uint8_t subindex, const bool completeAccess, const Value value) {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return bus_->sendSdoWrite(address_, index, subindex, completeAccess, value);
-}
-
-// This definition must not be in the header, because of the forward declaration of EthercatBus
-template <typename Value>
-bool EthercatSlaveBase::sendSdoRead(const uint16_t index, const uint8_t subindex, const bool completeAccess, Value& value) {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return bus_->sendSdoRead(address_, index, subindex, completeAccess, value);
-}
-
-// These definitions must not be in the header, because of the forward declaration of EthercatBus
-template bool EthercatSlaveBase::sendSdoWrite<int8_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                      const int8_t value);
-template bool EthercatSlaveBase::sendSdoWrite<int16_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                       const int16_t value);
-template bool EthercatSlaveBase::sendSdoWrite<int32_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                       const int32_t value);
-template bool EthercatSlaveBase::sendSdoWrite<int64_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                       const int64_t value);
-template bool EthercatSlaveBase::sendSdoWrite<uint8_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                       const uint8_t value);
-template bool EthercatSlaveBase::sendSdoWrite<uint16_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                        const uint16_t value);
-template bool EthercatSlaveBase::sendSdoWrite<uint32_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                        const uint32_t value);
-template bool EthercatSlaveBase::sendSdoWrite<uint64_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                        const uint64_t value);
-template bool EthercatSlaveBase::sendSdoWrite<float>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                     const float value);
-template bool EthercatSlaveBase::sendSdoWrite<double>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                      const double value);
-template bool EthercatSlaveBase::sendSdoWrite<std::string>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                           const std::string value);
-
-template bool EthercatSlaveBase::sendSdoRead<int8_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                     int8_t& value);
-template bool EthercatSlaveBase::sendSdoRead<int16_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                      int16_t& value);
-template bool EthercatSlaveBase::sendSdoRead<int32_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                      int32_t& value);
-template bool EthercatSlaveBase::sendSdoRead<int64_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                      int64_t& value);
-template bool EthercatSlaveBase::sendSdoRead<uint8_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                      uint8_t& value);
-template bool EthercatSlaveBase::sendSdoRead<uint16_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                       uint16_t& value);
-template bool EthercatSlaveBase::sendSdoRead<uint32_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                       uint32_t& value);
-template bool EthercatSlaveBase::sendSdoRead<uint64_t>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                       uint64_t& value);
-template bool EthercatSlaveBase::sendSdoRead<float>(const uint16_t index, const uint8_t subindex, const bool completeAccess, float& value);
-template bool EthercatSlaveBase::sendSdoRead<double>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                     double& value);
-template bool EthercatSlaveBase::sendSdoRead<std::string>(const uint16_t index, const uint8_t subindex, const bool completeAccess,
-                                                     std::string& value);
 
 bool EthercatSlaveBase::sendSdoReadGeneric(const std::string& indexString, const std::string& subindexString,
                                            const std::string& valueTypeString, std::string& valueString) {


### PR DESCRIPTION
# No SDO template hell
I switched the forward declaration solution for the circular dependency of EthercatSlaveBase and EthercatBusBase:

### Before:
EthercatSlaveBase.hpp:
```c++
class EthercatBusBase;
```
EthercatBusBase.hpp:
```c++
#include <soem_interface/EthercatSlaveBase.hpp>
```

### Now:
EthercatSlaveBase.hpp:
```c++
#include <soem_interface/EthercatBusBase.hpp>
```
EthercatBusBase.hpp:
```c++
class EthercatSlaveBase;
using EthercatSlaveBasePtr = std::shared_ptr<EthercatslaveBase>;
```

### Advantage of this version:
The `sendSdoRead` and `sendSdoWrite` templates of the `EthercatSlaveBase` can now be fully defined in `EthercatSlaveBase.hpp` which removes a lot of template instantiations.
Using new types for new devices is now also trivial (e.g. `std::array<uint32_t, 4>` in the `maxon_epos_ethercat_sdk`).

### Other:
I reimplemented the type-suffixed SDO calls (e.g. `sendSdoReadUint8`) and marked them as deprecated.
**This should ensure complete backwards compatability.**

## TODO:
Test on hardware.