### PR TITLE
System libs (pthread, rt on linux) as catkin dependencies

### DIFF
--- a/soem/CMakeLists.txt
+++ b/soem/CMakeLists.txt
@@ -53,7 +53,9 @@ catkin_package(
         ./soem/osal
         ./soem/osal/${OS}
         ./soem/oshw/${OS}
-   LIBRARIES soem)
+   LIBRARIES
+        soem
+        ${OS_LIBS})
 
 set(SOEM_INCLUDE_INSTALL_DIR include/soem)
 set(SOEM_LIB_INSTALL_DIR lib)


### PR DESCRIPTION
Currently the pthread and rt libraries are not exposed as dependencies to catkin.
