### PR TITLE
Shutdown state change fix

### DIFF
--- a/soem_interface_rsl/src/soem_interface_rsl/EthercatBusBase.cpp
+++ b/soem_interface_rsl/src/soem_interface_rsl/EthercatBusBase.cpp
@@ -664,6 +664,7 @@ struct EthercatBusBaseTemplateAdapter::EthercatSlaveBaseImpl {
                                                  << " has been reached after " << retry << " retries");
         return true;
       }
+      setStateLocked(state, slave);
     }
     MELO_WARN_STREAM("[soem_interface_rsl::" << name_ << "] Slave " << slave << ": Targetstate " << EthercatBusBase::getStateString(state)
                                              << " has not been reached. Current State: " << returnedState);


### PR DESCRIPTION
My implementation of soem_interface approximately half of the times faced a problem during shutdown, which caused the program to stall inside of waitForStateLocked when the program had been terminated. It was always waiting for the full amount of retries and yet the first slave was unable to reach the wanted state. By adding this one line of code (setStateLocked) after each retry, the slave always seemed to reach the desired state after max 1 retry.